### PR TITLE
Register LEDs (User LED DS4)

### DIFF
--- a/arch/arm64/boot/dts/compulab/ucm-imx8m-mini.dtsi
+++ b/arch/arm64/boot/dts/compulab/ucm-imx8m-mini.dtsi
@@ -34,6 +34,18 @@
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "heartbeat";
 		};
+
+		yellow-led {
+			label = "yellow-led";
+			gpios = <&gpio3 19 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		green-led {
+			label = "green-led";
+			gpios = <&gpio3 25 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
 	};
 
 	soc@0 {
@@ -377,6 +389,8 @@
 		pinctrl_gpio_led: gpioledgrp {
 			fsl,pins = <
 				MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x19
+				MX8MM_IOMUXC_SAI5_MCLK_GPIO3_IO25	0x19
+				MX8MM_IOMUXC_SAI5_RXFS_GPIO3_IO19	0x19
 			>;
 		};
 


### PR DESCRIPTION
iot-gate-imx8 reference describes the User LED (DS4) as a single unit controlled by 2 gpio lines (GPIO3_IO19, GPIO3_IO25). Linux led framework doesn't support this kind of "2-in-1" leds but having 2 separate entries for leds register is still much more convenient than doing gpio access manually.